### PR TITLE
Fix: soft keyboard messes up the canvas size

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -379,23 +379,24 @@ export function App() {
   }) {
     // Get the device pixel ratio, falling back to 1.
     const dpr = window.devicePixelRatio || 1
-    const height = Math.max(window.innerHeight, document.documentElement.clientHeight)
+    const fullHeight = document.documentElement.clientHeight
+    const fullWidth = document.documentElement.clientWidth
     return (
       <canvas
         ref={canvasRef}
         style={{
           backgroundColor: 'AliceBlue',
           display: 'block',
-          width: window.innerWidth,
-          height: height,
+          width: fullWidth,
+          height: fullHeight,
 
           // disable all touch behavior from browser, e.g. touch to scroll
           touchAction: 'none',
 
           ...(styleCursor ? { cursor: styleCursor } : {}),
         }}
-        width={window.innerWidth * dpr}
-        height={height * dpr}
+        width={fullWidth * dpr}
+        height={fullHeight * dpr}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -379,6 +379,7 @@ export function App() {
   }) {
     // Get the device pixel ratio, falling back to 1.
     const dpr = window.devicePixelRatio || 1
+    const height = Math.max(window.innerHeight, document.documentElement.clientHeight)
     return (
       <canvas
         ref={canvasRef}
@@ -386,7 +387,7 @@ export function App() {
           backgroundColor: 'AliceBlue',
           display: 'block',
           width: window.innerWidth,
-          height: window.innerHeight,
+          height: height,
 
           // disable all touch behavior from browser, e.g. touch to scroll
           touchAction: 'none',
@@ -394,7 +395,7 @@ export function App() {
           ...(styleCursor ? { cursor: styleCursor } : {}),
         }}
         width={window.innerWidth * dpr}
-        height={window.innerHeight * dpr}
+        height={height * dpr}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -379,6 +379,7 @@ export function App() {
   }) {
     // Get the device pixel ratio, falling back to 1.
     const dpr = window.devicePixelRatio || 1
+    // Why not window.innerHeight / innerWidth ? https://github.com/pobch/react-diagram/pull/35
     const fullHeight = document.documentElement.clientHeight
     const fullWidth = document.documentElement.clientWidth
     return (

--- a/src/index.css
+++ b/src/index.css
@@ -12,9 +12,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  /* TODO: Find a better way to resolve horizontal & vertical scrollbar in Chrome (Windows 10) */
-  /* https://github.com/pobch/react-diagram/issues/15 */
-  /* overflow: hidden; */
+  /* A safety net in case an accidental scrollbar appears because of the canvas size(a child of <body>) */
+  overflow: hidden;
 }
 
 code {

--- a/src/index.css
+++ b/src/index.css
@@ -14,7 +14,7 @@ body {
 
   /* TODO: Find a better way to resolve horizontal & vertical scrollbar in Chrome (Windows 10) */
   /* https://github.com/pobch/react-diagram/issues/15 */
-  overflow: hidden;
+  /* overflow: hidden; */
 }
 
 code {


### PR DESCRIPTION
## Why?
- #34 

## How?
Use `document.documentElement.clientHeight`/`clientWidth` to determine the canvas size instead of `window.innerHeight`/`innerWidth`

The difference:
![image](https://user-images.githubusercontent.com/19894957/185065697-038163a3-8e74-4b3f-b232-895d0961787b.png)

When a soft keyboard appears:
![image](https://user-images.githubusercontent.com/19894957/185068483-0ff4237e-40b2-45e6-abf5-e7ff0cccbda2.png)

